### PR TITLE
Support new JAX

### DIFF
--- a/lab/types.py
+++ b/lab/types.py
@@ -136,7 +136,7 @@ _ag_tensor = ModuleType("autograd.tracer", "Box")
 _ag_retrievables = [_ag_tensor]
 
 # Define JAX module types.
-_jax_tensor = ModuleType("jax.interpreters.xla", "DeviceArray")
+_jax_tensor = ModuleType("jaxlib.xla_extension", "ArrayImpl")
 _jax_tracer = ModuleType("jax.core", "Tracer")
 _jax_dtype = ModuleType("jax._src.numpy.lax_numpy", "_ScalarMeta")
 _jax_device = ModuleType("jaxlib.xla_extension", "Device")

--- a/lab/types.py
+++ b/lab/types.py
@@ -136,7 +136,10 @@ _ag_tensor = ModuleType("autograd.tracer", "Box")
 _ag_retrievables = [_ag_tensor]
 
 # Define JAX module types.
-_jax_tensor = ModuleType("jaxlib.xla_extension", "ArrayImpl")
+if sys.version_info.minor > 7:  # jax>0.4 deprecated python-3.7 support, rely on older jax versions
+    _jax_tensor = ModuleType("jaxlib.xla_extension", "ArrayImpl")
+else:
+    _jax_tensor = ModuleType("jax.interpreters.xla", "DeviceArray")
 _jax_tracer = ModuleType("jax.core", "Tracer")
 _jax_dtype = ModuleType("jax._src.numpy.lax_numpy", "_ScalarMeta")
 _jax_device = ModuleType("jaxlib.xla_extension", "Device")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ autograd>=1.3
 tensorflow>=2
 tensorflow-probability
 torch
-jax
+jax>=0.4
 jaxlib
 setuptools_scm[toml]
 setuptools_scm_git_archive

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ autograd>=1.3
 tensorflow>=2
 tensorflow-probability
 torch
-jax>=0.4
+jax
 jaxlib
 setuptools_scm[toml]
 setuptools_scm_git_archive


### PR DESCRIPTION
`jax=0.4.1` [introduces](https://github.com/google/jax/releases/tag/jax-v0.4.1) `Array` instead of `DeviceArray`. Also, support for Python 3.7 has been dropped.

This PR updates `_jax_tensor` accordingly, depending on the Python version.